### PR TITLE
pack: add back support for older mihomo kernel

### DIFF
--- a/modules/pack.py
+++ b/modules/pack.py
@@ -303,6 +303,7 @@ async def pack(url: list, urlstandalone: list, urlstandby:list, urlstandbystanda
         rule_providers["rule-providers"].update({
             name: {
                 **classical,
+                "path": "./rule/{}.txt".format(name),
                 "url": url
             }
         })


### PR DESCRIPTION
add back path field in rule-providers