### PR TITLE
修复了使用Caddy反向代理服务出现的地址错误

### DIFF
--- a/api.py
+++ b/api.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     else:
         print("robots: Allow")
     module_name = __name__.split(".")[0]
-    uvicorn.run(module_name+":app", host=args.host, port=args.port, workers=4)
+    uvicorn.run(module_name+":app", host=args.host, port=args.port, workers=4, proxy_headers=True, forwarded_allow_ips="*")
 
 
 """


### PR DESCRIPTION
使用发现如果仅仅使用正常的ip则可以获取节点，但是如果通过Caddy反向代理后获取的配置文件中的url是不带https头，这导致节点获取失败。
```
proxy-providers:
  subscription0:
    type: http
    url: http://xxx.com
```
修复方式，通过指定 `proxy_headers=True`获取真正的`request.base_url`
```
uvicorn.run(module_name+":app", host=args.host, port=args.port, workers=4, proxy_headers=True, forwarded_allow_ips="*")
```
测试结果输出正常
```
proxy-providers:
  subscription0:
    type: http
    url: https://xxx.com
    interval: 1800
```