### PR TITLE
v3.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 static/
 config.yaml
 .omx/
+.sisyphus/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v3.0.1] - 2026-04-16
+
+### Fixes
+
+- Fix Docker/Nuitka startup path resolution so onefile builds load external runtime files from the executable directory
+
+**Full Changelog**: https://github.com/SubConv/SubConv/compare/v3.0.0...v3.0.1
+
 ## [v3.0.0] - 2026-04-11
 
 ### Breaking Changes

--- a/api.py
+++ b/api.py
@@ -6,8 +6,9 @@ from subconv.cli import main
 
 if __name__ == "__main__":
     import os
+    import sys
     from pathlib import Path
 
-    os.chdir(Path(__file__).resolve().parent)
+    os.chdir(Path(sys.argv[0]).resolve().parent)
 
     main()


### PR DESCRIPTION
Fix Docker/Nuitka startup path resolution so onefile builds load external runtime files from the executable directory