### PR TITLE
feat: 支持指定订阅域名强制直连

### DIFF
--- a/docs/guide/advanced-usage/apis.md
+++ b/docs/guide/advanced-usage/apis.md
@@ -12,8 +12,11 @@ It accepts GET requests. Here're the parameters:
 | template | Template ID used to render the final config. | Yes | zju | Built-in values are `zju` and `general`. When omitted, `zju` is used. |
 | interval | The interval of proxy update. | Yes | 1800 | Unit: seconds. |
 | urlstandby | The URL of the standby subscription or node sharing link. The proxies in it will only be added to the **manual switch group** (the group whose `"manual"` is `True` in the configuration file), and will not be classified into region groups. **It's recommended to be URIComponent encoded.** | Yes | - | Multiple subscription links are supported. You can use line breaks or "|" to separate them. |
+| direct | Original subscription URLs or hosts that should be forced to `DIRECT` in the generated mihomo rules. **It needs to be URIComponent encoded.** | Yes | - | Use line breaks or "|" to separate multiple entries. Each host must come from `url` or `urlstandby`; otherwise the request returns 400. This only adds exact `DOMAIN,<host>,DIRECT` rules. |
 | short | If this parameter is set (regardless of its value), the header section and dns section containing allow-lan will not be generated. | Yes | - | - |
 | npr | If this parameter is set (regardless of its value), the URL of the ruleset will not be proxied. | Yes | - | By default, this service is used to proxy the URL of the ruleset to ensure that the ruleset can be obtained normally. If this parameter is set, the URL of the ruleset will not be proxied. |
+
+`direct` is intended for local gateway or transparent proxy deployments. It makes the generated mihomo config route selected original subscription domains directly, so SubConv's later backend fetches are less likely to be trapped by a broken proxy chain when the same mihomo instance handles transparent proxy traffic. It does not change how SubConv's HTTP client connects, and it does not solve the first generation request if the backend cannot fetch the original subscription before the generated config is loaded.
 
 ## GET /provider
 This API converts the subscription to the configuration required by proxy-provider. This API will be called whenever the proxy is updated via proxy-provider.

--- a/docs/zh_CN/guide/advanced-usage/apis.md
+++ b/docs/zh_CN/guide/advanced-usage/apis.md
@@ -12,8 +12,11 @@
 | template | 用于渲染最终配置的模板 ID。 | 是 | zju | 当前内置值为 `zju` 和 `general`。不传时默认使用 `zju`。 |
 | interval | 代理更新间隔。 | 是 | 1800 | 单位：秒。 |
 | urlstandby | 备用订阅链接或节点分享链接。其中的代理将仅添加到**手动切换组**(配置文件中`"manual"`为`True`的组)中，并不会归类到区域组中。**建议进行URIComponent编码。** | 是 | - | 支持多个订阅链接。您可以使用换行符或"|"分隔它们。 |
+| direct | 需要在生成的 mihomo 规则中强制 `DIRECT` 的原始订阅链接或域名。**需要进行URIComponent编码。** | 是 | - | 支持用换行符或"|"分隔多个条目。每个域名必须来自 `url` 或 `urlstandby`，否则请求返回 400。只会生成精确的 `DOMAIN,<host>,DIRECT` 规则。 |
 | short | 如果设置了此参数（无论取值为何），将不会生成包含 allow-lan 等内容的标头部分和 dns 部分。 | 是 | - | - |
 | npr | 如果设置了此参数（无论取值为何），将不会代理 ruleset 的 URL | 是 | - | 默认情况下，会使用这个服务来代理 ruleset 的 URL，以保证能正常获取规则集。若设置了此参数，将不会代理 ruleset 的 URL。 |
+
+`direct` 主要用于本地网关或透明代理部署场景。它会让生成的 mihomo 配置把指定原始订阅域名直连，从而在同一个 mihomo 实例承载透明代理流量时，降低 SubConv 后续后端拉取订阅被失效代理链路卡住的概率。它不会改变 SubConv 后端 HTTP client 本身的连接方式，也不能解决首次生成配置前后端已经无法拉取原始订阅的冷启动问题。
 
 ## GET /provider
 此API可将订阅转换为 proxy-provider 需要的配置。每当通过 proxy-provider 更新代理时，将调用此API。

--- a/mainpage/src/App.vue
+++ b/mainpage/src/App.vue
@@ -14,8 +14,14 @@
 
             <el-form label-position="right" label-width="100px" class="main">
                 <el-form-item label="订阅">
-                    <el-input type="textarea" v-model="linkInput" rows="5" resize="none"
-                        placeholder="请粘贴订阅链接，或者分享链接，多个订阅链接请换行或用|符号隔开"></el-input>
+                    <div class="subscription-list">
+                        <div class="subscription-row" v-for="item in subscriptions" :key="item.id">
+                            <el-input v-model="item.value" placeholder="请粘贴订阅链接或分享链接" @paste="handleSubscriptionPaste($event, item.id, subscriptions)"></el-input>
+                            <el-switch v-model="item.direct" active-text="强制直连"></el-switch>
+                            <el-button @click="removeSubscription(item.id)" :disabled="subscriptions.length === 1">删除</el-button>
+                        </div>
+                        <el-button @click="addSubscription">添加订阅</el-button>
+                    </div>
                 </el-form-item>
 
                 <el-form-item label="模板">
@@ -41,8 +47,14 @@
 
                 <el-form-item label="备用节点">
                     <el-switch v-model="standby_switch" active-text="备用节点只会出现在手动选择分组"></el-switch>
-                    <el-input type="textarea" v-model="standby" rows="5" resize="none" v-if="standby_switch"
-                        placeholder="请粘贴备用节点，多个备用节点请换行或用|符号隔开"></el-input>
+                    <div class="subscription-list standby-list" v-if="standby_switch">
+                        <div class="subscription-row" v-for="item in standbySubscriptions" :key="item.id">
+                            <el-input v-model="item.value" placeholder="请粘贴备用节点或备用订阅" @paste="handleSubscriptionPaste($event, item.id, standbySubscriptions)"></el-input>
+                            <el-switch v-model="item.direct" active-text="强制直连"></el-switch>
+                            <el-button @click="removeStandbySubscription(item.id)" :disabled="standbySubscriptions.length === 1">删除</el-button>
+                        </div>
+                        <el-button @click="addStandbySubscription">添加备用</el-button>
+                    </div>
                 </el-form-item>
 
                 <el-form-item label="更新间隔">
@@ -96,10 +108,24 @@ import 'element-plus/es/components/switch/style/css'
 import 'element-plus/es/components/select/style/css'
 import 'element-plus/es/components/option/style/css'
 import 'element-plus/es/components/message/style/css'
-const linkInput = ref('')
+
+type SubscriptionInput = {
+    id: number,
+    value: string,
+    direct: boolean
+}
+
+let nextSubscriptionId = 1
+const createSubscriptionInput = (): SubscriptionInput => ({
+    id: nextSubscriptionId++,
+    value: '',
+    direct: false
+})
+
+const subscriptions = ref<SubscriptionInput[]>([createSubscriptionInput()])
+const standbySubscriptions = ref<SubscriptionInput[]>([createSubscriptionInput()])
 const linkOutput = ref('')
 const time = ref('')
-const standby = ref('')
 const defaultTemplate = ref<string | null>(null)
 const selectedTemplate = ref<string | null>(null)
 const availableTemplates = ref<string[]>([])
@@ -107,6 +133,70 @@ const isLoadingRuntimeConfig = ref(true)
 const hasRuntimeConfigError = ref(false)
 const standby_switch = ref(false)
 const proxy_switch = ref(true)
+
+const splitSubscriptionInput = (value: string): string[] => value
+    .split(/[|\n]/)
+    .map((item) => item.trim())
+    .filter((item) => item !== '')
+
+const collectSubscriptions = (items: SubscriptionInput[]): string[] => items
+    .flatMap((item) => splitSubscriptionInput(item.value))
+
+const collectDirectSubscriptions = (items: SubscriptionInput[]): string[] => items
+    .filter((item) => item.direct)
+    .flatMap((item) => splitSubscriptionInput(item.value))
+
+const isRemoteSubscription = (value: string) => (
+    (value.startsWith('http://') || value.startsWith('https://')) && !value.startsWith('https://t.me/')
+)
+
+const hasInvalidDirectTarget = (items: string[]) => items.some((item) => !isRemoteSubscription(item))
+
+const addSubscription = () => {
+    subscriptions.value.push(createSubscriptionInput())
+}
+
+const removeSubscription = (id: number) => {
+    if (subscriptions.value.length === 1) {
+        return
+    }
+    subscriptions.value = subscriptions.value.filter((item) => item.id !== id)
+}
+
+const addStandbySubscription = () => {
+    standbySubscriptions.value.push(createSubscriptionInput())
+}
+
+const removeStandbySubscription = (id: number) => {
+    if (standbySubscriptions.value.length === 1) {
+        return
+    }
+    standbySubscriptions.value = standbySubscriptions.value.filter((item) => item.id !== id)
+}
+
+const handleSubscriptionPaste = (event: ClipboardEvent, id: number, items: SubscriptionInput[]) => {
+    const text = event.clipboardData?.getData('text') ?? ''
+    const values = splitSubscriptionInput(text)
+    if (values.length <= 1) {
+        return
+    }
+
+    event.preventDefault()
+    const index = items.findIndex((item) => item.id === id)
+    if (index === -1) {
+        return
+    }
+
+    items.splice(
+        index,
+        1,
+        ...values.map((value) => ({
+            ...createSubscriptionInput(),
+            value,
+            direct: items[index].direct
+        }))
+    )
+}
 
 const templateOptions = computed(() => [
     ...availableTemplates.value.map((templateName) => ({
@@ -192,7 +282,14 @@ onMounted(async () => {
 // methods
 const submitForm = () => {
     let result = window.location.protocol + "//" + window.location.host
-    if (linkInput.value !== "") {
+    const primarySubscriptions = collectSubscriptions(subscriptions.value)
+    const standbyValues = standby_switch.value ? collectSubscriptions(standbySubscriptions.value) : []
+    const directSubscriptions = [
+        ...collectDirectSubscriptions(subscriptions.value),
+        ...(standby_switch.value ? collectDirectSubscriptions(standbySubscriptions.value) : [])
+    ]
+
+    if (primarySubscriptions.length > 0) {
         if (!selectedTemplate.value) {
             ElMessage({
                 message: '模板配置加载失败，请刷新网页后重试',
@@ -201,7 +298,15 @@ const submitForm = () => {
             linkOutput.value = ""
             return false;
         }
-        result += "/sub?url=" + encodeURIComponent(linkInput.value);
+        if (hasInvalidDirectTarget(directSubscriptions)) {
+            ElMessage({
+                message: '强制直连仅支持 http/https 原始订阅链接',
+                type: 'error'
+            });
+            linkOutput.value = ""
+            return false;
+        }
+        result += "/sub?url=" + encodeURIComponent(primarySubscriptions.join('\n'));
         result += "&template=" + encodeURIComponent(selectedTemplate.value);
         if (time.value !== "") {
             if (/^[1-9][0-9]*$/.test(time.value)) {
@@ -217,9 +322,12 @@ const submitForm = () => {
             }
         }
         if (standby_switch.value) {
-            if (standby.value !== "") {
-                result += "&urlstandby=" + encodeURIComponent(standby.value);
+            if (standbyValues.length > 0) {
+                result += "&urlstandby=" + encodeURIComponent(standbyValues.join('\n'));
             }
+        }
+        if (directSubscriptions.length > 0) {
+            result += "&direct=" + encodeURIComponent(directSubscriptions.join('\n'));
         }
         if (!proxy_switch.value) {
             result += "&npr=1";
@@ -254,6 +362,32 @@ const copyForm = () => {
 
 .main {
     margin-top: 60px;
+}
+
+.subscription-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+}
+
+.subscription-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+}
+
+.subscription-row :deep(.el-input) {
+    flex: 1;
+}
+
+.subscription-row :deep(.el-switch) {
+    flex: 0 0 auto;
+}
+
+.standby-list {
+    margin-top: 12px;
 }
 
 .header {

--- a/subconv/app.py
+++ b/subconv/app.py
@@ -1,6 +1,7 @@
 import re
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import urlencode, urlparse
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -8,7 +9,6 @@ from fastapi.requests import Request
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
-from urllib.parse import urlencode
 
 from . import config
 from . import packer
@@ -73,6 +73,7 @@ async def sub(request: Request):
     interval = args.get("interval", "1800")
     short = args.get("short")
     notproxyrule = args.get("npr")
+    direct_param = args.get("direct")
     template_name = _resolve_template_name(args.get("template"))
     template_config = await _load_template(template_name)
 
@@ -98,6 +99,7 @@ async def sub(request: Request):
         if urlstandbystandalone_raw
         else None
     )
+    direct_hosts = _resolve_direct_hosts(direct_param, url, urlstandby)
 
     user_agent = request.headers.get("User-Agent", "v2rayn")
 
@@ -143,6 +145,7 @@ async def sub(request: Request):
         urlstandalone=urlstandalone,
         urlstandby=urlstandby,
         urlstandbystandalone=urlstandbystandalone,
+        direct_hosts=direct_hosts,
         content=content,
         interval=interval,
         domain=domain,
@@ -261,6 +264,67 @@ def _validate_remote_url(url: str) -> str:
         raise HTTPException(status_code=400, detail=f"Invalid upstream URL: {url}")
 
     return str(parsed)
+
+
+def _resolve_direct_hosts(
+    direct_param: str | None,
+    url: list[str] | None,
+    urlstandby: list[str] | None,
+) -> list[str] | None:
+    if direct_param is None or direct_param.strip() == "":
+        return None
+
+    allowed_hosts = {
+        host
+        for source in (url or []) + (urlstandby or [])
+        if (host := _resolve_remote_url_host(source)) is not None
+    }
+    direct_hosts: list[str] = []
+    for item in filter(None, re.split(r"[|\n]", direct_param)):
+        candidate = item.strip()
+        if candidate == "":
+            continue
+        host = _resolve_direct_host(candidate)
+        if host is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid direct target: {candidate}",
+            )
+        if host not in allowed_hosts:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Direct target is not present in url/urlstandby: {candidate}",
+            )
+        if host not in direct_hosts:
+            direct_hosts.append(host)
+
+    return direct_hosts or None
+
+
+def _resolve_direct_host(candidate: str) -> str | None:
+    if candidate.startswith(("http://", "https://")):
+        try:
+            parsed = httpx.URL(candidate)
+        except httpx.InvalidURL:
+            return None
+        return parsed.host.lower() if parsed.host is not None else None
+
+    if "/" in candidate or "?" in candidate or "#" in candidate:
+        return None
+
+    parsed = urlparse(f"//{candidate}")
+    return parsed.hostname.lower() if parsed.hostname is not None else None
+
+
+def _resolve_remote_url_host(url: str) -> str | None:
+    try:
+        parsed = httpx.URL(url)
+    except httpx.InvalidURL as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid upstream URL: {url}") from exc
+
+    if parsed.scheme not in {"http", "https"} or parsed.host is None:
+        raise HTTPException(status_code=400, detail=f"Invalid upstream URL: {url}")
+    return parsed.host.lower()
 
 
 async def _fetch_remote_response(

--- a/subconv/packer.py
+++ b/subconv/packer.py
@@ -17,6 +17,7 @@ async def pack(
     urlstandalone: list[ProxyMapping] | None,
     urlstandby: list[str] | None,
     urlstandbystandalone: list[ProxyMapping] | None,
+    direct_hosts: list[str] | None,
     content: list[str] | None,
     interval: str,
     domain: str,
@@ -309,6 +310,9 @@ async def pack(
     rules: dict[str, list[str]] = {"rules": []}
     rules_list = rules["rules"]
     rules_list.append(f"DOMAIN,{domain},DIRECT")
+    if direct_hosts:
+        for host in direct_hosts:
+            rules_list.append(f"DOMAIN,{host},DIRECT")
     for k, v in rule_map.items():
         if not k.startswith("[]"):
             rules_list.append(f"RULE-SET,{k},{v}")


### PR DESCRIPTION
## Summary
- add `direct` support for selected original subscription hosts
- generate exact `DOMAIN,<host>,DIRECT` rules before provider rule sets
- expose per-subscription force-direct switches in the Web UI
- document the transparent proxy deployment boundary

Fixes #130

## Notes
This keeps existing `/sub` links compatible. The new behavior is only enabled when `direct` is present or when the Web UI force-direct switch is used.